### PR TITLE
[WIP]: Query arguments generation

### DIFF
--- a/src/hypothesis_graphql/_strategies/primitives.py
+++ b/src/hypothesis_graphql/_strategies/primitives.py
@@ -1,0 +1,60 @@
+"""Strategies for simple types like scalars or enums."""
+from typing import Union
+
+import graphql
+from hypothesis import strategies as st
+
+from ..types import ScalarValueNode
+
+
+def scalar(type_: graphql.GraphQLScalarType, nullable: bool = True) -> st.SearchStrategy[ScalarValueNode]:
+    if type_.name == "Int":
+        return int_(nullable)
+    if type_.name == "Float":
+        return float_(nullable)
+    if type_.name == "String":
+        return string(nullable)
+    if type_.name == "ID":
+        return id_(nullable)
+    if type_.name == "Boolean":
+        return boolean(nullable)
+    raise TypeError("Custom scalar types are not supported")
+
+
+def enum(type_: graphql.GraphQLEnumType, nullable: bool = True) -> st.SearchStrategy[graphql.EnumValueNode]:
+    enum_value = st.sampled_from(sorted(type_.values))
+    if nullable:
+        enum_value |= st.none()
+    return st.builds(graphql.EnumValueNode, value=enum_value)
+
+
+def int_(nullable: bool = True) -> st.SearchStrategy[graphql.IntValueNode]:
+    value = st.integers().map(str)
+    if nullable:
+        value |= st.none()
+    return st.builds(graphql.IntValueNode, value=value)
+
+
+def float_(nullable: bool = True) -> st.SearchStrategy[graphql.FloatValueNode]:
+    value = st.floats(allow_infinity=False, allow_nan=False).map(str)
+    if nullable:
+        value |= st.none()
+    return st.builds(graphql.FloatValueNode, value=value)
+
+
+def string(nullable: bool = True) -> st.SearchStrategy[graphql.StringValueNode]:
+    value = st.text()
+    if nullable:
+        value |= st.none()
+    return st.builds(graphql.StringValueNode, value=value)
+
+
+def id_(nullable: bool = True) -> st.SearchStrategy[Union[graphql.StringValueNode, graphql.IntValueNode]]:
+    return string(nullable) | int_(nullable)
+
+
+def boolean(nullable: bool = True) -> st.SearchStrategy[graphql.BooleanValueNode]:
+    value = st.booleans()
+    if nullable:
+        value |= st.none()
+    return st.builds(graphql.BooleanValueNode, value=value)

--- a/src/hypothesis_graphql/_strategies/queries.py
+++ b/src/hypothesis_graphql/_strategies/queries.py
@@ -1,12 +1,17 @@
 """Strategies for GraphQL queries."""
 from functools import partial
-from typing import List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 import graphql
+from graphql.pyutils import FrozenList
 from hypothesis import strategies as st
+
+from ..types import Field, InputTypeNode
+from . import primitives
 
 
 def query(schema: str) -> st.SearchStrategy[str]:
+    """A strategy for generating valid queries for the given GraphQL schema."""
     parsed_schema = graphql.build_schema(schema)
     if parsed_schema.query_type is None:
         raise ValueError("Query type is not defined in the schema")
@@ -16,9 +21,7 @@ def query(schema: str) -> st.SearchStrategy[str]:
 def fields(object_type: graphql.GraphQLObjectType) -> st.SearchStrategy[List[graphql.FieldNode]]:
     """Generate a subset of fields defined on the given type."""
     # minimum 1 field, an empty query is not valid
-    field_pairs = tuple(object_type.fields.items())
-    # pairs are unique by field name
-    return st.lists(st.sampled_from(field_pairs), min_size=1, unique_by=lambda x: x[0]).flatmap(list_of_field_nodes)
+    return subset_of_fields(**object_type.fields).flatmap(lists_of_field_nodes)
 
 
 make_selection_set_node = partial(graphql.SelectionSetNode, kind="selection_set")
@@ -38,15 +41,11 @@ def make_query(selections: List[graphql.FieldNode]) -> graphql.DocumentNode:
     )
 
 
-def list_of_field_nodes(items: List[Tuple[str, graphql.GraphQLField]]) -> st.SearchStrategy[List[graphql.FieldNode]]:
-    """Generate a list of `graphql.FieldNode`."""
-    return st.tuples(*(field_nodes(name, field) for name, field in items)).map(list)
-
-
 def field_nodes(name: str, field: graphql.GraphQLField) -> st.SearchStrategy[graphql.FieldNode]:
     """Generate a single field node with optional children."""
     return st.builds(
         partial(graphql.FieldNode, name=graphql.NameNode(value=name)),  # type: ignore
+        arguments=list_of_arguments(**field.args),
         selection_set=st.builds(make_selection_set_node, selections=fields_for_type(field)),
     )
 
@@ -54,9 +53,141 @@ def field_nodes(name: str, field: graphql.GraphQLField) -> st.SearchStrategy[gra
 def fields_for_type(field: graphql.GraphQLField) -> st.SearchStrategy[Optional[List[graphql.FieldNode]]]:
     """Extract proper type from the field and generate field nodes for this type."""
     type_ = field.type
-    if isinstance(type_, graphql.GraphQLScalarType):
-        return st.none()
-    if isinstance(type_, graphql.GraphQLList):
+    # TODO. What if this field is a list?
+    if isinstance(type_, graphql.GraphQLWrappingType):
         type_ = type_.of_type
-    # TODO. handle other types, e.g. GraphQLEnumType
-    return fields(type_)  # type: ignore
+    if isinstance(type_, graphql.GraphQLObjectType):
+        return fields(type_)
+    # Only object has field, others don't
+    return st.none()
+
+
+def list_of_arguments(**kwargs: graphql.GraphQLArgument) -> st.SearchStrategy[List[graphql.ArgumentNode]]:
+    """Generate a list `graphql.ArgumentNode` for a field."""
+    return st.tuples(
+        *(
+            st.builds(partial(graphql.ArgumentNode, name=graphql.NameNode(value=name)), value=argument_values(argument))  # type: ignore
+            for name, argument in kwargs.items()
+        )
+    ).map(finalize_arguments)
+
+
+def finalize_arguments(nodes: Tuple[graphql.ArgumentNode, ...]) -> List[graphql.ArgumentNode]:
+    """Nodes might be generated with empty values, and they should be removed from the output."""
+    return [remove_empty(node) for node in nodes if not is_empty(node.value)]
+
+
+def is_empty(node: graphql.ValueNode) -> bool:
+    # The checked values often can't be None, but generated as such.
+    # It will be better if this value won't be generated at all,
+    # but in this case argument node shouldn't be generated as well - there might be some better way to handle
+    # empty arguments without overriding actual node types (example - what if `None` is actually a valid value?)
+    if isinstance(
+        node,
+        (
+            graphql.IntValueNode,
+            graphql.FloatValueNode,
+            graphql.StringValueNode,
+            graphql.BooleanValueNode,
+            graphql.EnumValueNode,
+        ),
+    ):
+        return node.value is None
+    if isinstance(node, graphql.ListValueNode):
+        return node.values is None
+    if isinstance(node, graphql.ObjectValueNode):
+        return node.fields is None
+    # VariableNode or NullValueNode
+    return False
+
+
+def remove_empty(node: graphql.ArgumentNode) -> graphql.ArgumentNode:
+    """Remove empty children from list nodes."""
+    _remove_empty(node.value)
+    return node
+
+
+def _remove_empty(node: graphql.ValueNode) -> graphql.ValueNode:
+    """Recursive part for removing empty child nodes."""
+    if isinstance(node, graphql.ListValueNode) and node.values is not None:
+        node.values = FrozenList([_remove_empty(node) for node in node.values if not is_empty(node)])
+    return node
+
+
+def argument_values(argument: graphql.GraphQLArgument) -> st.SearchStrategy[InputTypeNode]:
+    """Value of `graphql.ArgumentNode`."""
+    return value_nodes(argument.type)
+
+
+def value_nodes(type_: graphql.GraphQLInputType) -> st.SearchStrategy[InputTypeNode]:
+    """Generate value nodes of a type, that corresponds to the input type.
+
+    They correspond to all `GraphQLInputType` variants:
+        - GraphQLScalarType -> ScalarValueNode
+        - GraphQLEnumType -> EnumValueNode
+        - GraphQLInputObjectType -> ObjectValueNode
+
+    GraphQLWrappingType[T] is unwrapped:
+        - GraphQLList -> ListValueNode[T]
+        - GraphQLNonNull -> T (processed with nullable=False)
+    """
+    type_, nullable = check_nullable(type_)
+    # Types without children
+    if isinstance(type_, graphql.GraphQLScalarType):
+        return primitives.scalar(type_, nullable)
+    if isinstance(type_, graphql.GraphQLEnumType):
+        return primitives.enum(type_, nullable)
+    # Types with children
+    if isinstance(type_, graphql.GraphQLList):
+        return lists(type_, nullable)
+    if isinstance(type_, graphql.GraphQLInputObjectType):
+        return objects(type_, nullable)
+    raise TypeError(f"Type {type_.__class__.__name__} is not supported.")
+
+
+def check_nullable(type_: graphql.GraphQLInputType) -> Tuple[graphql.GraphQLInputType, bool]:
+    """Get the wrapped type and detect if it is nullable."""
+    nullable = True
+    if isinstance(type_, graphql.GraphQLNonNull):
+        type_ = type_.of_type
+        nullable = False
+    return type_, nullable
+
+
+def lists(type_: graphql.GraphQLList, nullable: bool = True) -> st.SearchStrategy[graphql.ListValueNode]:
+    """Generate a `graphql.ListValueNode`."""
+    type_ = type_.of_type
+    list_value = st.lists(value_nodes(type_))
+    if nullable:
+        list_value |= st.none()
+    return st.builds(graphql.ListValueNode, values=list_value)
+
+
+def objects(type_: graphql.GraphQLInputObjectType, nullable: bool = True) -> st.SearchStrategy[graphql.ObjectValueNode]:
+    """Generate a `graphql.ObjectValueNode`."""
+    fields_value = subset_of_fields(**type_.fields).flatmap(list_of_object_field_nodes)
+    if nullable:
+        fields_value |= st.none()
+    return st.builds(graphql.ObjectValueNode, fields=fields_value)
+
+
+def subset_of_fields(**all_fields: Field) -> st.SearchStrategy[List[Tuple[str, Field]]]:
+    """A helper to select a subset of fields."""
+    field_pairs = sorted(all_fields.items())
+    # pairs are unique by field name
+    return st.lists(st.sampled_from(field_pairs), min_size=1, unique_by=lambda x: x[0])
+
+
+def object_field_nodes(name: str, field: graphql.GraphQLInputField) -> st.SearchStrategy[graphql.ObjectFieldNode]:
+    return st.builds(
+        partial(graphql.ObjectFieldNode, name=graphql.NameNode(value=name)),  # type: ignore
+        value=value_nodes(field.type),
+    )
+
+
+def list_of_nodes(items: List[Tuple], strategy: Callable[[str, Field], st.SearchStrategy],) -> st.SearchStrategy[List]:
+    return st.tuples(*(strategy(name, field) for name, field in items)).map(list)
+
+
+list_of_object_field_nodes = partial(list_of_nodes, strategy=object_field_nodes)
+lists_of_field_nodes = partial(list_of_nodes, strategy=field_nodes)

--- a/src/hypothesis_graphql/types.py
+++ b/src/hypothesis_graphql/types.py
@@ -1,0 +1,8 @@
+from typing import Union
+
+import graphql
+
+# Leaf nodes, that don't have children
+ScalarValueNode = Union[graphql.IntValueNode, graphql.FloatValueNode, graphql.StringValueNode, graphql.BooleanValueNode]
+InputTypeNode = Union[ScalarValueNode, graphql.EnumValueNode, graphql.ListValueNode, graphql.ObjectValueNode]
+Field = Union[graphql.GraphQLField, graphql.GraphQLInputField]

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -1,8 +1,10 @@
 import graphql
 import pytest
+from graphql import GraphQLNamedType
 from hypothesis import given
 
 import hypothesis_graphql.strategies as gql_st
+from hypothesis_graphql._strategies.queries import value_nodes
 
 SCHEMA = """
 type Book {
@@ -13,6 +15,30 @@ type Book {
 type Author {
   name: String
   books: [Book]
+}
+
+enum Color {
+  RED
+  GREEN
+  BLUE
+}
+
+input QueryInput {
+  eq: String
+  ne: String
+}
+
+input NestedQueryInput {
+  code: QueryInput
+}
+
+type Model {
+  int: Int,
+  float: Float,
+  string: String
+  id: ID,
+  boolean: Boolean
+  color: Color
 }
 """
 
@@ -32,10 +58,51 @@ def assert_schema(schema):
       getBooks: [Book]
       getAuthors: [Author]
     }""",
+        """type Query {
+      getBooksByAuthor(name: String): [Book]
+    }""",
     ),
 )
 def test_query(query):
     assert_schema(SCHEMA + query)
+
+
+@pytest.mark.parametrize("notnull", (True, False))
+@pytest.mark.parametrize(
+    "arguments, node_names",
+    (
+        ("int: Int", ("IntValueNode",)),
+        ("float: Float", ("FloatValueNode",)),
+        ("string: String", ("StringValueNode",)),
+        ("id: ID", ("IntValueNode", "StringValueNode")),
+        ("boolean: Boolean", ("BooleanValueNode",)),
+        ("color: Color", ("EnumValueNode",)),
+        ("contain: [Int]", ("ListValueNode", "IntValueNode")),
+        ("contain: [Float]", ("ListValueNode", "FloatValueNode")),
+        ("contain: [String]", ("ListValueNode", "StringValueNode")),
+        ("contain: [Boolean]", ("ListValueNode", "BooleanValueNode")),
+        ("contain: [Color]", ("ListValueNode", "EnumValueNode")),
+        ("contain: [[Int]]", ("ListValueNode", "IntValueNode")),
+        ("contains: QueryInput", ("ObjectValueNode",)),
+        ("contains: NestedQueryInput", ("ObjectValueNode",)),
+    ),
+)
+def test_arguments(arguments, node_names, notnull):
+    if notnull:
+        arguments += "!"
+    query_type = f"""type Query {{
+      getModel({arguments}): Model
+    }}"""
+
+    @given(query=gql_st.query(SCHEMA + query_type))
+    def test(query):
+        for node_name in node_names:
+            assert node_name not in query
+        if notnull:
+            assert "getModel(" in query
+        graphql.parse(query)
+
+    test()
 
 
 def test_missing_query():
@@ -44,3 +111,35 @@ def test_missing_query():
     }"""
     with pytest.raises(ValueError, match="Query type is not defined in the schema"):
         gql_st.query(schema)
+
+
+def test_unknown_type():
+    # If there will be a new input type in `graphql`
+
+    class NewType(GraphQLNamedType):
+        pass
+
+    with pytest.raises(TypeError, match="Type NewType is not supported."):
+        value_nodes(NewType("Test"))
+
+
+def test_custom_scalar():
+    # custom scalar types are not supported directly
+    schema = """
+    scalar Date
+
+    type Object {
+      created: Date
+    }
+
+    type Query {
+      getByDate(created: Date): Object
+    }
+    """
+
+    @given(query=gql_st.query(schema))
+    def test(query):
+        pass
+
+    with pytest.raises(TypeError, match="Custom scalar types are not supported"):
+        test()


### PR DESCRIPTION
Types:

- [x] String
- [x] ID
- [x] Int
- [x] Float
- [x] Boolean
- [x] Enums
- [x] Objects
- [x] NotNull
- [x] List
- [x] Nested lists
- [x] Nullable lists

Other:
- [x] Docs for all functions
- [x] Test for not supported type (e.g. if it will occur in a new version of `graphql`
- [x] Test for custom scalar error

Custom scalar types are out of scope - we don't know how to generate them. Maybe there could be some validation error like proposed in `hypothesis-jsonschema`

Resolves #9 