### PR TITLE
chore: Handle custom scalars gracefully

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,3 @@
+from hypothesis import settings
+
+settings.register_profile("fast", max_examples=10)


### PR DESCRIPTION
Raises an exception if the type is not nullable. In general, it might be controlled by some config option - in some cases, it is still possible to generate some queries.

This PR allows skipping nullable argument types