### PR TITLE
fix: Do not generate Unicode surrogates for `String` types

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- Do not generate Unicode surrogates for ``String`` types. `#30`_
+
 `0.4.0`_ - 2021-03-27
 ---------------------
 
@@ -61,3 +65,5 @@ Changelog
 .. _0.3.2: https://github.com/stranger6667/hypothesis-graphql/compare/v0.3.1...v0.3.2
 .. _0.3.1: https://github.com/stranger6667/hypothesis-graphql/compare/v0.3.0...v0.3.1
 .. _0.3.0: https://github.com/stranger6667/hypothesis-graphql/compare/v0.2.0...v0.3.0
+
+.. _#30: https://github.com/Stranger6667/hypothesis-graphql/30

--- a/src/hypothesis_graphql/_strategies/primitives.py
+++ b/src/hypothesis_graphql/_strategies/primitives.py
@@ -43,7 +43,7 @@ def float_(nullable: bool = True) -> st.SearchStrategy[graphql.FloatValueNode]:
 
 
 def string(nullable: bool = True) -> st.SearchStrategy[graphql.StringValueNode]:
-    value = st.text()
+    value = st.text(alphabet=st.characters(blacklist_categories=("Cs",), max_codepoint=0xFFFF))
     if nullable:
         value |= st.none()
     return st.builds(graphql.StringValueNode, value=value)


### PR DESCRIPTION
Fixes #30 