### PR TITLE
perf: Use `hypothesis.strategies.recursive` for building queries

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Performance**
+
+- Use ```hypothesis.strategies.recursive`` for building queries which leads to ~7.5x average generation speed.
+
 `0.4.2`_ - 2021-04-21
 ---------------------
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -30,7 +30,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "graphql-core"
-version = "3.1.2"
+version = "3.1.4"
 description = "GraphQL implementation for Python, a port of GraphQL.js, the JavaScript reference implementation for GraphQL."
 category = "main"
 optional = false
@@ -38,7 +38,7 @@ python-versions = ">=3.6,<4"
 
 [[package]]
 name = "hypothesis"
-version = "6.0.2"
+version = "6.10.0"
 description = "A library for property-based testing"
 category = "main"
 optional = false
@@ -49,8 +49,8 @@ attrs = ">=19.2.0"
 sortedcontainers = ">=2.1.0,<3.0.0"
 
 [package.extras]
-all = ["black (>=19.10b0)", "click (>=7.0)", "django (>=2.2)", "dpcontracts (>=0.4)", "lark-parser (>=0.6.5)", "libcst (>=0.3.16)", "numpy (>=1.9.0)", "pandas (>=0.25)", "pytest (>=4.3)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "importlib-resources (>=3.3.0)", "importlib-metadata", "backports.zoneinfo (>=0.2.1)", "tzdata (>=2020.4)"]
-cli = ["click (>=7.0)", "black (>=19.10b0)"]
+all = ["black (>=19.10b0)", "click (>=7.0)", "django (>=2.2)", "dpcontracts (>=0.4)", "lark-parser (>=0.6.5)", "libcst (>=0.3.16)", "numpy (>=1.9.0)", "pandas (>=0.25)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "importlib-resources (>=3.3.0)", "importlib-metadata", "backports.zoneinfo (>=0.2.1)", "tzdata (>=2020.4)"]
+cli = ["click (>=7.0)", "black (>=19.10b0)", "rich (>=9.0.0)"]
 codemods = ["libcst (>=0.3.16)"]
 dateutil = ["python-dateutil (>=1.4)"]
 django = ["pytz (>=2014.1)", "django (>=2.2)"]
@@ -59,14 +59,14 @@ ghostwriter = ["black (>=19.10b0)"]
 lark = ["lark-parser (>=0.6.5)"]
 numpy = ["numpy (>=1.9.0)"]
 pandas = ["pandas (>=0.25)"]
-pytest = ["pytest (>=4.3)"]
+pytest = ["pytest (>=4.6)"]
 pytz = ["pytz (>=2014.1)"]
 redis = ["redis (>=3.0.0)"]
 zoneinfo = ["importlib-resources (>=3.3.0)", "backports.zoneinfo (>=0.2.1)", "tzdata (>=2020.4)"]
 
 [[package]]
 name = "importlib-metadata"
-version = "3.4.0"
+version = "4.0.1"
 description = "Read metadata from Python packages"
 category = "dev"
 optional = false
@@ -78,19 +78,19 @@ zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
-name = "more-itertools"
-version = "8.6.0"
-description = "More routines for operating on iterables, beyond itertools"
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = "*"
 
 [[package]]
 name = "packaging"
-version = "20.8"
+version = "20.9"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
@@ -131,25 +131,24 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "pytest"
-version = "5.4.3"
+version = "6.2.3"
 description = "pytest: simple powerful testing with Python"
 category = "dev"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.dependencies]
 atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
-attrs = ">=17.4.0"
+attrs = ">=19.2.0"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
-more-itertools = ">=4.0.0"
+iniconfig = "*"
 packaging = "*"
-pluggy = ">=0.12,<1.0"
-py = ">=1.5.0"
-wcwidth = "*"
+pluggy = ">=0.12,<1.0.0a1"
+py = ">=1.8.2"
+toml = "*"
 
 [package.extras]
-checkqa-mypy = ["mypy (v0.761)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
@@ -161,6 +160,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
 name = "typing-extensions"
 version = "3.7.4.3"
 description = "Backported and Experimental Type Hints for Python 3.5+"
@@ -169,29 +176,21 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "wcwidth"
-version = "0.2.5"
-description = "Measures the displayed width of unicode strings in a terminal"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "zipp"
-version = "3.4.0"
+version = "3.4.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "17dec4a705e1f4220dd6b8764cf46039e2b24d9fdef4477a6b41aaf9cef6a86c"
+content-hash = "2a6c5af5cc06e11d523bab5e6136a52a10ee2912f5d67f42f2f95d848ca7e924"
 
 [metadata.files]
 atomicwrites = [
@@ -204,26 +203,27 @@ attrs = [
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 graphql-core = [
-    {file = "graphql-core-3.1.2.tar.gz", hash = "sha256:c056424cbdaa0ff67446e4379772f43746bad50a44ec23d643b9bdcd052f5b3a"},
-    {file = "graphql_core-3.1.2-py3-none-any.whl", hash = "sha256:b1826fbd1c6c290f7180d758ecf9c3859a46574cff324bf35a10167533c0e463"},
+    {file = "graphql-core-3.1.4.tar.gz", hash = "sha256:972eff18416ad90815c95914b754486270f13fbe1a24e010c7eedbaa903b9386"},
+    {file = "graphql_core-3.1.4-py3-none-any.whl", hash = "sha256:2ae62ed27eb5c629fdfd06f89bec36a427bef97d37aef41e8f195c5352f22bea"},
 ]
 hypothesis = [
-    {file = "hypothesis-6.0.2-py3-none-any.whl", hash = "sha256:58ecc8e368be95688d01b1dee788f5b1c1e3d0f31043dc19f014f241f40fa187"},
-    {file = "hypothesis-6.0.2.tar.gz", hash = "sha256:ae616551c8ebe897454e2de5183e325f6a109f70d45b7380154ed974ce8d4772"},
+    {file = "hypothesis-6.10.0-py3-none-any.whl", hash = "sha256:1a00a4e3ef40041b2c072deab9c71e307bc5354bb4a102ef22ae8c23fa8b3970"},
+    {file = "hypothesis-6.10.0.tar.gz", hash = "sha256:9f8c130b1278d30cb3cc64e3a4aacb88c4906155772beed90ce33e06794e1ee0"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-3.4.0-py3-none-any.whl", hash = "sha256:ace61d5fc652dc280e7b6b4ff732a9c2d40db2c0f92bc6cb74e07b73d53a1771"},
-    {file = "importlib_metadata-3.4.0.tar.gz", hash = "sha256:fa5daa4477a7414ae34e95942e4dd07f62adf589143c875c133c1e53c4eff38d"},
+    {file = "importlib_metadata-4.0.1-py3-none-any.whl", hash = "sha256:d7eb1dea6d6a6086f8be21784cc9e3bcfa55872b52309bc5fad53a8ea444465d"},
+    {file = "importlib_metadata-4.0.1.tar.gz", hash = "sha256:8c501196e49fb9df5df43833bdb1e4328f64847763ec8a50703148b73784d581"},
 ]
-more-itertools = [
-    {file = "more-itertools-8.6.0.tar.gz", hash = "sha256:b3a9005928e5bed54076e6e549c792b306fddfe72b2d1d22dd63d42d5d3899cf"},
-    {file = "more_itertools-8.6.0-py3-none-any.whl", hash = "sha256:8e1a2a43b2f2727425f2b5839587ae37093f19153dc26c0927d1048ff6557330"},
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 packaging = [
-    {file = "packaging-20.8-py2.py3-none-any.whl", hash = "sha256:24e0da08660a87484d1602c30bb4902d74816b6985b93de36926f5bc95741858"},
-    {file = "packaging-20.8.tar.gz", hash = "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"},
+    {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
+    {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
 ]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
@@ -238,23 +238,23 @@ pyparsing = [
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 pytest = [
-    {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},
-    {file = "pytest-5.4.3.tar.gz", hash = "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"},
+    {file = "pytest-6.2.3-py3-none-any.whl", hash = "sha256:6ad9c7bdf517a808242b998ac20063c41532a570d088d77eec1ee12b0b5574bc"},
+    {file = "pytest-6.2.3.tar.gz", hash = "sha256:671238a46e4df0f3498d1c3270e5deb9b32d25134c99b7d75370a68cfbe9b634"},
 ]
 sortedcontainers = [
     {file = "sortedcontainers-2.3.0-py2.py3-none-any.whl", hash = "sha256:37257a32add0a3ee490bb170b599e93095eed89a55da91fa9f48753ea12fd73f"},
     {file = "sortedcontainers-2.3.0.tar.gz", hash = "sha256:59cc937650cf60d677c16775597c89a960658a09cf7c1a668f86e1e4464b10a1"},
+]
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
     {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
     {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
 ]
-wcwidth = [
-    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
-    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
-]
 zipp = [
-    {file = "zipp-3.4.0-py3-none-any.whl", hash = "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108"},
-    {file = "zipp-3.4.0.tar.gz", hash = "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"},
+    {file = "zipp-3.4.1-py3-none-any.whl", hash = "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"},
+    {file = "zipp-3.4.1.tar.gz", hash = "sha256:3607921face881ba3e026887d8150cca609d517579abe052ac81fc5aeffdbd76"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,10 @@ license = "MIT"
 python = "^3.6"
 hypothesis = ">5.8.0"
 graphql-core = "^3.1.0"
+attrs = "^20.3.0"
 
 [tool.poetry.dev-dependencies]
-pytest = "^5.4.1"
+pytest = ">5.4.1"
 
 [tool.black]
 line-length = 120
@@ -41,7 +42,7 @@ multi_line_output = 3
 default_section = "THIRDPARTY"
 include_trailing_comma = true
 known_first_party = "hypothesis_graphql"
-known_third_party =["graphql", "hypothesis", "hypothesis_graphql", "pytest"]
+known_third_party =["attr", "graphql", "hypothesis", "hypothesis_graphql", "pytest"]
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/src/hypothesis_graphql/_strategies/queries.py
+++ b/src/hypothesis_graphql/_strategies/queries.py
@@ -1,12 +1,84 @@
 """Strategies for GraphQL queries."""
 from functools import partial
-from typing import Callable, Iterable, List, Optional, Tuple, Union
+from typing import Callable, Dict, Generator, Iterable, List, Optional, Tuple, TypeVar, Union
 
+import attr
 import graphql
 from hypothesis import strategies as st
+from hypothesis.strategies._internal.core import defines_strategy
 
 from ..types import Field, InputTypeNode
 from . import primitives
+
+T = TypeVar("T")
+Draw = Callable[[st.SearchStrategy[T]], T]
+FieldTuple = Tuple[str, Field]
+FieldTuples = List[FieldTuple]
+
+
+@attr.s(slots=True)
+class Node:
+    """Node of an intermediate output tree."""
+
+    name: str = attr.ib()
+    type: graphql.GraphQLNamedType = attr.ib()
+    children: List["Node"] = attr.ib()
+    field: Optional[Field] = attr.ib(default=None)
+    args: Optional[List[graphql.ArgumentNode]] = attr.ib(default=None)
+    already_extended: bool = attr.ib(default=False)
+
+    @classmethod
+    def from_object_type(cls, object_type: graphql.GraphQLObjectType, children: FieldTuples) -> "Node":
+        return cls(
+            name=object_type.name,
+            type=object_type,
+            children=cls.into_nodes(children),
+        )
+
+    @classmethod
+    def from_field(cls, name: str, field: Field, args: Optional[List[graphql.ArgumentNode]] = None) -> "Node":
+        return cls(name=name, field=field, type=unwrap_field_type(field), args=args, children=[])
+
+    @classmethod
+    def into_nodes(cls, tuples: FieldTuples) -> List["Node"]:
+        return [cls.from_field(name, field) for name, field in tuples]
+
+    def __iter__(self) -> Generator["Node", None, None]:
+        """Depth-first tree traversal."""
+        for child in self.children:
+            yield from child
+            yield child
+
+    @property
+    def is_complete(self) -> bool:
+        """Whether this node requires further modifications.
+
+        Unless nodes are complete we can't build a valid GraphQL query from it.
+        """
+        if isinstance(self.field, graphql.GraphQLField):
+            # All not-nullable arguments should be present
+            for name, arg in self.field.args.items():
+                if graphql.is_non_null_type(arg.type):
+                    if self.args:
+                        if not any(existing_arg.name.value == name for existing_arg in self.args):
+                            return False
+                    else:
+                        return False
+        if isinstance(self.type, graphql.GraphQLObjectType):
+            # Objects should have at least one field
+            return bool(self.children)
+        return True
+
+    def as_field_nodes(self) -> List[graphql.FieldNode]:
+        """Convert this intermediate tree node and all its children to GraphQL AST nodes."""
+        return [
+            graphql.FieldNode(
+                name=graphql.NameNode(value=child.name),
+                arguments=child.args,
+                selection_set=graphql.SelectionSetNode(kind="selection_set", selections=child.as_field_nodes()),
+            )
+            for child in self.children
+        ]
 
 
 def query(schema: Union[str, graphql.GraphQLSchema], fields: Optional[Iterable[str]] = None) -> st.SearchStrategy[str]:
@@ -21,86 +93,154 @@ def query(schema: Union[str, graphql.GraphQLSchema], fields: Optional[Iterable[s
         parsed_schema = graphql.build_schema(schema)
     else:
         parsed_schema = schema
-    if parsed_schema.query_type is None:
+    query_type = parsed_schema.query_type
+    if query_type is None:
         raise ValueError("Query type is not defined in the schema")
     if fields is not None:
         fields = tuple(fields)
-        if not fields:
-            raise ValueError("If you pass `fields`, it should not be empty")
-        invalid_fields = tuple(field for field in fields if field not in parsed_schema.query_type.fields)
-        if invalid_fields:
-            raise ValueError(f"Unknown fields: {', '.join(invalid_fields)}")
-    return _fields(parsed_schema.query_type, fields=fields).map(make_query).map(graphql.print_ast)
+        validate_fields(query_type, fields)
+    # Building process:
+    #  1. Generate an intermediate tree. Each node contains information like field type, arguments, etc
+    #  2. Convert that tree to GraphQL AST
+    #  3. Convert AST to a string
+    return query_tree(query_type, fields).map(tree_to_ast).map(graphql.print_ast)
 
 
-def _fields(
-    object_type: graphql.GraphQLObjectType, fields: Optional[Tuple[str, ...]] = None
-) -> st.SearchStrategy[List[graphql.FieldNode]]:
-    """Generate a subset of fields defined on the given type."""
+def validate_fields(query_type: graphql.GraphQLObjectType, fields: Tuple[str, ...]) -> None:
+    """Check whether the passed field tuple contains valid field names."""
+    if not fields:
+        raise ValueError("If you pass `fields`, it should not be empty")
+    invalid_fields = tuple(field for field in fields if field not in query_type.fields)
+    if invalid_fields:
+        raise ValueError(f"Unknown fields: {', '.join(invalid_fields)}")
+
+
+@defines_strategy()  # type: ignore
+def query_tree(
+    query_type: graphql.GraphQLObjectType, fields: Optional[Tuple[str, ...]] = None
+) -> st.SearchStrategy[Node]:
+    """Return an intermediate tree for a GraphQL query type.
+
+    Tree building process:
+      1. Create a root node.
+      2. Extend it with child nodes
+      3. Finish incomplete nodes
+
+    We don't know upfront if some nodes will require at least one child. For example, Object field types require at
+    least one field to be present in selection. Therefore we first build an incomplete tree fast, using Hypothesis's
+    recursive strategy, and then finish incomplete nodes.
+    """
     if fields:
-        subset = {name: value for name, value in object_type.fields.items() if name in fields}
+        selection = {name: value for name, value in query_type.fields.items() if name in fields}
     else:
-        subset = object_type.fields
-    # minimum 1 field, an empty query is not valid
-    return subset_of_fields(**subset).flatmap(lists_of_field_nodes)
+        selection = query_type.fields
+    return st.recursive(
+        root(query_type, selection),
+        extend_tree,
+    ).flatmap(finish_tree)
 
 
-make_selection_set_node = partial(graphql.SelectionSetNode, kind="selection_set")
+@st.composite  # type: ignore
+def root(draw: Draw, object_type: graphql.GraphQLObjectType, selection: Dict[str, graphql.GraphQLField]) -> Node:
+    """Create a root node."""
+    fields = draw(fields_sample(selection))
+    return Node.from_object_type(object_type, fields)
 
 
-def make_query(selections: List[graphql.FieldNode]) -> graphql.DocumentNode:
-    """Create top-level node for a query AST."""
+@st.composite  # type: ignore
+def extend_tree(draw: Draw, tree_strategy: st.SearchStrategy[Node]) -> Node:
+    """Extend generated tree with additional nodes & arguments."""
+    tree = draw(tree_strategy)
+    for node in tree:
+        if not node.already_extended:
+            if isinstance(node.type, graphql.GraphQLObjectType):
+                node.children = draw(fields_sample(node.type.fields).map(Node.into_nodes))
+            if node.field.args:
+                node.args = draw(list_of_arguments(node.field.args))
+            node.already_extended = True
+    return tree
+
+
+@st.composite  # type: ignore
+def finish_tree(draw: Draw, tree: Node) -> Node:
+    # It should finish incomplete nodes
+    # object types should have at least one field selected - this should run until all nodes are valid
+    # try to finish it as soon as possible, as the main growing process happens in `extend_tree`
+    for node in tree:
+        while not node.is_complete:
+            if isinstance(node.field, graphql.GraphQLField) and node.field.args:
+                node.args = draw(list_of_arguments(node.field.args))
+            if isinstance(node.type, graphql.GraphQLObjectType):
+                fields = draw(fields_sample(node.type.fields))
+                non_object_fields = [
+                    (name, field) for name, field in fields if not isinstance(field, graphql.GraphQLObjectType)
+                ]
+                if non_object_fields:
+                    node.children = Node.into_nodes(non_object_fields)
+                else:
+                    node.children = Node.into_nodes(fields)
+                    finish_tree(node)
+    return tree
+
+
+@defines_strategy()  # type: ignore
+def fields_sample(fields: Dict[str, T]) -> st.SearchStrategy[List[Tuple[str, T]]]:
+    """Return a list of unique (name, field) pairs drawn from the input fields.
+
+    The results are used to select a subset of possible fields in GraphQL queries.
+    """
+    if len(fields) == 1:
+        # If there is only one field, then we can skip sampling and take this field directly
+        pair = tuple(fields.items())[0]
+        return st.just([pair])
+    pairs = sorted(fields.items())
+    samples = st.sampled_from(pairs)
+
+    def by_name(pair: FieldTuple) -> str:
+        # pairs should be unique by field name - they will be used to construct a JSON object on the server side
+        # and according to RFC 7159 non-unique keys in objects may lead to unpredictable behavior during the parsing
+        # step. Often only the latest key will be taken, but we can prevent it here
+        return pair[0]
+
+    return st.lists(samples, min_size=1, unique_by=by_name)
+
+
+def unwrap_field_type(field: Field) -> graphql.GraphQLNamedType:
+    """Get the underlying field type which is not wrapped."""
+    type_ = field.type
+    while isinstance(type_, graphql.GraphQLWrappingType):
+        type_ = type_.of_type
+    return type_
+
+
+def tree_to_ast(tree: Node) -> graphql.DocumentNode:
+    """Build AST from a generated tree."""
     return graphql.DocumentNode(
         kind="document",
         definitions=[
             graphql.OperationDefinitionNode(
                 kind="operation_definition",
                 operation=graphql.OperationType.QUERY,
-                selection_set=make_selection_set_node(selections=selections),
+                selection_set=graphql.SelectionSetNode(kind="selection_set", selections=tree.as_field_nodes()),
             )
         ],
     )
 
 
-def field_nodes(name: str, field: graphql.GraphQLField) -> st.SearchStrategy[graphql.FieldNode]:
-    """Generate a single field node with optional children."""
-    return st.builds(
-        partial(graphql.FieldNode, name=graphql.NameNode(value=name)),
-        arguments=list_of_arguments(**field.args),
-        selection_set=st.builds(make_selection_set_node, selections=fields_for_type(field)),
-    )
-
-
-def fields_for_type(field: graphql.GraphQLField) -> st.SearchStrategy[Optional[List[graphql.FieldNode]]]:
-    """Extract proper type from the field and generate field nodes for this type."""
-    type_ = field.type
-    while isinstance(type_, graphql.GraphQLWrappingType):
-        type_ = type_.of_type
-    if isinstance(type_, graphql.GraphQLObjectType):
-        return _fields(type_)
-    # Only object has field, others don't
-    return st.none()
-
-
-def list_of_arguments(**kwargs: graphql.GraphQLArgument) -> st.SearchStrategy[List[graphql.ArgumentNode]]:
+def list_of_arguments(arguments: Dict[str, graphql.GraphQLArgument]) -> st.SearchStrategy[List[graphql.ArgumentNode]]:
     """Generate a list `graphql.ArgumentNode` for a field."""
-    args = []
-    for name, argument in kwargs.items():
+    argument_strategies = []
+    for name, argument in arguments.items():
         try:
-            argument_strategy = argument_values(argument)
+            argument_strategy = value_nodes(argument.type)
         except TypeError as exc:
             if not isinstance(argument.type, graphql.GraphQLNonNull):
                 continue
             raise TypeError("Non-nullable custom scalar types are not supported as arguments") from exc
-        args.append(
+        argument_strategies.append(
             st.builds(partial(graphql.ArgumentNode, name=graphql.NameNode(value=name)), value=argument_strategy)
         )
-    return st.tuples(*args).map(list)
-
-
-def argument_values(argument: graphql.GraphQLArgument) -> st.SearchStrategy[InputTypeNode]:
-    """Value of `graphql.ArgumentNode`."""
-    return value_nodes(argument.type)
+    return st.tuples(*argument_strategies).map(list)
 
 
 def value_nodes(type_: graphql.GraphQLInputType) -> st.SearchStrategy[InputTypeNode]:
@@ -138,31 +278,26 @@ def check_nullable(type_: graphql.GraphQLInputType) -> Tuple[graphql.GraphQLInpu
     return type_, nullable
 
 
-def lists(type_: graphql.GraphQLList, nullable: bool = True) -> st.SearchStrategy[graphql.ListValueNode]:
+def lists(list_type: graphql.GraphQLList, nullable: bool = True) -> st.SearchStrategy[graphql.ListValueNode]:
     """Generate a `graphql.ListValueNode`."""
-    type_ = type_.of_type
-    list_value = st.lists(value_nodes(type_))
+    list_value = st.lists(value_nodes(list_type.of_type))
     if nullable:
         list_value |= st.none()
     return st.builds(graphql.ListValueNode, values=list_value)
 
 
-def objects(type_: graphql.GraphQLInputObjectType, nullable: bool = True) -> st.SearchStrategy[graphql.ObjectValueNode]:
+def objects(
+    object_type: graphql.GraphQLInputObjectType, nullable: bool = True
+) -> st.SearchStrategy[graphql.ObjectValueNode]:
     """Generate a `graphql.ObjectValueNode`."""
-    fields_value = subset_of_fields(**type_.fields).flatmap(list_of_object_field_nodes)
+    fields_value = fields_sample(object_type.fields).flatmap(list_of_nodes)
     if nullable:
         fields_value |= st.none()
     return st.builds(graphql.ObjectValueNode, fields=fields_value)
 
 
-def subset_of_fields(**all_fields: Field) -> st.SearchStrategy[List[Tuple[str, Field]]]:
-    """A helper to select a subset of fields."""
-    field_pairs = sorted(all_fields.items())
-    # pairs are unique by field name
-    return st.lists(st.sampled_from(field_pairs), min_size=1, unique_by=lambda x: x[0])
-
-
 def object_field_nodes(name: str, field: graphql.GraphQLInputField) -> st.SearchStrategy[graphql.ObjectFieldNode]:
+    """Generate AST node for an input field."""
     return st.builds(
         partial(graphql.ObjectFieldNode, name=graphql.NameNode(value=name)),
         value=value_nodes(field.type),
@@ -170,11 +305,7 @@ def object_field_nodes(name: str, field: graphql.GraphQLInputField) -> st.Search
 
 
 def list_of_nodes(
-    items: List[Tuple],
-    strategy: Callable[[str, Field], st.SearchStrategy],
-) -> st.SearchStrategy[List]:
-    return st.tuples(*(strategy(name, field) for name, field in items)).map(list)
-
-
-list_of_object_field_nodes = partial(list_of_nodes, strategy=object_field_nodes)
-lists_of_field_nodes = partial(list_of_nodes, strategy=field_nodes)
+    items: List[Tuple[str, graphql.GraphQLInputField]]
+) -> st.SearchStrategy[List[graphql.ObjectFieldNode]]:
+    """Strategy for generating lists of AST nodes for input fields."""
+    return st.tuples(*(object_field_nodes(name, field) for name, field in items)).map(list)

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -193,7 +193,7 @@ def test_minimal_queries(query, minimum):
     strategy = gql_st.query(schema)
     minimal_query = f"""{{
   getAuthors{minimum} {{
-    name
+    books
   }}
 }}"""
     assert find(strategy, lambda x: True).strip() == minimal_query


### PR DESCRIPTION
- [ ] More comments & docstrings
- [ ] Re-check coverage & verify whether some old code is still needed
- [ ] Why multiple queries generated for `test_custom_scalar_argument_nullable` ? At the moment all of them are the same
- [ ] Make argument generation recursive as well


Next steps:
- Produce complete subtrees instead, it is better to have valid nodes by construction;
- Use a two-level approach - for the root node, fill children from a recursive strategy;
