### PR TITLE
fix:  Generate only 32-bit signed integers for the `Int` type

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,10 @@ Changelog
 `Unreleased`_ - TBD
 -------------------
 
+**Fixed**
+
+- Generate only 32-bit signed integers for the ``Int`` type. `#40`_
+
 `0.4.2`_ - 2021-04-21
 ---------------------
 
@@ -78,5 +82,6 @@ Changelog
 .. _0.3.1: https://github.com/stranger6667/hypothesis-graphql/compare/v0.3.0...v0.3.1
 .. _0.3.0: https://github.com/stranger6667/hypothesis-graphql/compare/v0.2.0...v0.3.0
 
+.. _#40: https://github.com/Stranger6667/hypothesis-graphql/40
 .. _#32: https://github.com/Stranger6667/hypothesis-graphql/32
 .. _#30: https://github.com/Stranger6667/hypothesis-graphql/30

--- a/src/hypothesis_graphql/_strategies/primitives.py
+++ b/src/hypothesis_graphql/_strategies/primitives.py
@@ -6,6 +6,9 @@ from hypothesis import strategies as st
 
 from ..types import ScalarValueNode
 
+MIN_INT = -(2 ** 31)
+MAX_INT = 2 ** 31 - 1
+
 
 def scalar(type_: graphql.GraphQLScalarType, nullable: bool = True) -> st.SearchStrategy[ScalarValueNode]:
     if type_.name == "Int":
@@ -27,7 +30,7 @@ def enum(type_: graphql.GraphQLEnumType, nullable: bool = True) -> st.SearchStra
 
 
 def int_(nullable: bool = True) -> st.SearchStrategy[graphql.IntValueNode]:
-    value = st.integers().map(str)
+    value = st.integers(min_value=MIN_INT, max_value=MAX_INT).map(str)
     return _maybe_null(st.builds(graphql.IntValueNode, value=value), nullable)
 
 


### PR DESCRIPTION
Fixes #40 