### PR TITLE
chore: Cache parsed schemas

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,19 @@ Then strategies might be used in this way:
         #   }
         # }
 
-To restrict the set of fields in generated queries use the ``fields`` argument:
+
+    @given(mutation=gql_st.mutations(SCHEMA))
+    def test_mutation(mutation):
+        ...
+        # This mutation might be generated:
+        #
+        # mutation {
+        #   addBook(title: "H4Z\u7869", author: "\u00d2"){
+        #     title
+        #   }
+        # }
+
+To restrict the set of fields in generated operations use the ``fields`` argument:
 
 .. code:: python
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,10 @@ Changelog
 - Python 3.10 support.
 - Mutations support. `#51`_
 
+**Changed**
+
+- Cache parsed GraphQL schemas.
+
 `0.5.1`_ - 2021-08-05
 ---------------------
 

--- a/src/hypothesis_graphql/_strategies/validation.py
+++ b/src/hypothesis_graphql/_strategies/validation.py
@@ -2,10 +2,12 @@ from typing import Dict, Tuple, Union
 
 import graphql
 
+from ..cache import cached_build_schema
+
 
 def maybe_parse_schema(schema: Union[str, graphql.GraphQLSchema]) -> graphql.GraphQLSchema:
     if isinstance(schema, str):
-        return graphql.build_schema(schema)
+        return cached_build_schema(schema)
     return schema
 
 

--- a/src/hypothesis_graphql/cache.py
+++ b/src/hypothesis_graphql/cache.py
@@ -1,0 +1,8 @@
+from functools import lru_cache
+
+import graphql
+
+
+@lru_cache(maxsize=32)
+def cached_build_schema(schema: str) -> graphql.GraphQLSchema:
+    return graphql.build_schema(schema)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,8 +1,8 @@
-from functools import lru_cache
-
 import graphql
 import pytest
 from hypothesis import HealthCheck, settings
+
+from hypothesis_graphql.cache import cached_build_schema
 
 settings.register_profile("default", suppress_health_check=[HealthCheck.too_slow], deadline=None)
 settings.load_profile("default")
@@ -77,22 +77,10 @@ def schema():
 
 
 @pytest.fixture(scope="session")
-def build_schema():
-    # Parses a GraphQL schema. Caching is required to avoid re-parsing in each Hypothesis test as schemas are mostly
-    # static
-
-    @lru_cache()
-    def inner(schema: str):
-        return graphql.build_schema(schema)
-
-    return inner
-
-
-@pytest.fixture(scope="session")
-def validate_operation(build_schema):
+def validate_operation():
     def inner(schema, query):
         if isinstance(schema, str):
-            parsed_schema = build_schema(schema)
+            parsed_schema = cached_build_schema(schema)
         else:
             parsed_schema = schema
         query_ast = graphql.parse(query)

--- a/test/test_corpus.py
+++ b/test/test_corpus.py
@@ -1,7 +1,7 @@
 import json
 
 import pytest
-from hypothesis import HealthCheck, given, settings
+from hypothesis import HealthCheck, Phase, Verbosity, given, settings
 from hypothesis import strategies as st
 
 from hypothesis_graphql import strategies as gql_st
@@ -37,6 +37,8 @@ def get_names(corpus, predicate=None):
 
 CORPUS_SETTINGS = {
     "suppress_health_check": [HealthCheck.too_slow, HealthCheck.data_too_large, HealthCheck.filter_too_much],
+    "phases": [Phase.generate],
+    "verbosity": Verbosity.quiet,
     "deadline": None,
     "max_examples": 5,
 }

--- a/test/test_queries.py
+++ b/test/test_queries.py
@@ -6,6 +6,7 @@ from hypothesis import strategies as st
 
 from hypothesis_graphql import strategies as gql_st
 from hypothesis_graphql._strategies.selections import value_nodes
+from hypothesis_graphql.cache import cached_build_schema
 
 
 @pytest.fixture(scope="session")
@@ -60,7 +61,7 @@ def test_query_from_graphql_schema(data, schema, validate_operation):
     query = """type Query {
       getBooksByAuthor(name: String): [Book]
     }"""
-    schema = graphql.build_schema(schema + query)
+    schema = cached_build_schema(schema + query)
     query = data.draw(gql_st.query(schema))
     validate_operation(schema, query)
 
@@ -127,7 +128,7 @@ def test_arguments(data, schema, arguments, node_names, notnull, validate_operat
 @given(data=st.data())
 def test_interface(data, schema, query_type, validate_operation):
     schema = schema + query_type
-    parsed_schema = graphql.build_schema(schema)
+    parsed_schema = cached_build_schema(schema)
     query = data.draw(gql_st.query(schema))
     validate_operation(parsed_schema, query)
 


### PR DESCRIPTION
Parsed results depend only on the input string, so caching should be safe. This change dramatically helps with tests duration