### PR TITLE
perf: Cache `min_depths` and `build_oracle` per schema instead of recomputing them for every root field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased] - TBD
 
+### Performance
+
+- Cache `min_depths` and `build_oracle` per schema instead of recomputing them for every root field.
+
 ## [0.13.0] - 2026-05-29
 
 ### Changed

--- a/src/hypothesis_graphql/_strategies/oracle.py
+++ b/src/hypothesis_graphql/_strategies/oracle.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 import math
+from functools import lru_cache
 
 import graphql
 
@@ -97,6 +98,7 @@ def selset_values(schema: graphql.GraphQLSchema, roots: frozenset, x: float) -> 
     return _solve(types, _field_terms(schema, types), x)
 
 
+@lru_cache(maxsize=32)
 def min_depths(schema: graphql.GraphQLSchema) -> dict[str, int | None]:
     # Shortest number of selection levels from a type to a leaf field; None if unreachable.
     # Bellman-Ford-style fixpoint over the type graph -- order-independent.
@@ -142,6 +144,12 @@ class Oracle:
 
 
 def build_oracle(schema: graphql.GraphQLSchema, roots: frozenset, target_size: float = 8.0) -> Oracle:
+    # `roots` may arrive as a plain `set`; normalize before it hits the cache key below.
+    return _build_oracle_cached(schema, frozenset(roots), target_size)
+
+
+@lru_cache(maxsize=32)
+def _build_oracle_cached(schema: graphql.GraphQLSchema, roots: frozenset, target_size: float) -> Oracle:
     # Precompute field terms once; the binary search below reuses them across all solves.
     types = _reachable_composites(schema, roots)
     terms = _field_terms(schema, types)

--- a/test/test_oracle.py
+++ b/test/test_oracle.py
@@ -1,6 +1,6 @@
 import graphql
 
-from hypothesis_graphql._strategies.oracle import min_depths, selectable_fields
+from hypothesis_graphql._strategies.oracle import build_oracle, min_depths, selectable_fields
 
 
 def schema(sdl):
@@ -49,11 +49,21 @@ def test_selset_values_recursive_converges_below_rho():
 
 
 def test_build_oracle_returns_probabilities():
-    from hypothesis_graphql._strategies.oracle import build_oracle
-
     s = schema("type Query { a: Int b: String c: Query }")
     oracle = build_oracle(s, {"Query"}, target_size=3.0)
     probs = oracle.inclusion_probabilities("Query")
     assert set(probs) == {("a", None), ("b", None), ("c", None)}
     assert all(0.0 < p < 1.0 for p in probs.values())
     assert probs[("c", None)] > 0.05  # composite self-field not p^d-collapsed
+
+
+def test_min_depths_is_cached_per_schema():
+    s = schema("type Query { a: A } type A { f: String g: A }")
+    assert min_depths(s) is min_depths(s)
+
+
+def test_build_oracle_is_cached_per_schema_and_roots():
+    s = schema("type Query { a: Int b: String c: Query }")
+    first = build_oracle(s, frozenset({"Query"}), target_size=3.0)
+    second = build_oracle(s, frozenset({"Query"}), target_size=3.0)
+    assert first is second


### PR DESCRIPTION
…